### PR TITLE
feat: file block metadata without aes

### DIFF
--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -21,7 +21,6 @@ import { Data, Reference } from '@ethersphere/bee-js'
 import { getRawMetadata } from '../content-items/utils'
 import { assertRawFileMetadata, combine } from '../directory/utils'
 import { assertEncryptedReference, EncryptedReference } from '../utils/hex'
-import { encryptBytes } from '../utils/encryption'
 
 /**
  * Files management class
@@ -85,7 +84,7 @@ export class File {
     const blocks: Blocks = { blocks: [] }
     for (let i = 0; i < blocksCount; i++) {
       const currentBlock = data.slice(i * options.blockSize, (i + 1) * options.blockSize)
-      const result = await uploadBytes(connection, encryptBytes(pod.password, currentBlock))
+      const result = await uploadBytes(connection, currentBlock)
       blocks.blocks.push({
         size: currentBlock.length,
         compressedSize: currentBlock.length,
@@ -93,7 +92,7 @@ export class File {
       })
     }
 
-    const manifestBytes = encryptBytes(pod.password, stringToBytes(blocksToManifest(blocks)))
+    const manifestBytes = stringToBytes(blocksToManifest(blocks))
     const blocksReference = (await uploadBytes(connection, manifestBytes)).reference
     const meta: FileMetadata = {
       version: META_VERSION,

--- a/src/file/handler.ts
+++ b/src/file/handler.ts
@@ -6,8 +6,7 @@ import { FileMetadata } from '../pod/types'
 import { rawFileMetadataToFileMetadata } from './adapter'
 import { assertRawFileMetadata } from '../directory/utils'
 import { getRawMetadata } from '../content-items/utils'
-import { decryptBytes, PodPasswordBytes } from '../utils/encryption'
-import { bytesToHex } from '../utils/hex'
+import { PodPasswordBytes } from '../utils/encryption'
 
 /**
  * File prefix
@@ -63,7 +62,7 @@ export async function downloadData(
     throw new Error('Compressed data is not supported yet')
   }
 
-  const blocks = await downloadBlocksManifest(bee, podPassword, fileMetadata.blocksReference, downloadOptions)
+  const blocks = await downloadBlocksManifest(bee, fileMetadata.blocksReference, downloadOptions)
 
   let totalLength = 0
   for (const block of blocks.blocks) {
@@ -73,7 +72,7 @@ export async function downloadData(
   const result = new Uint8Array(totalLength)
   let offset = 0
   for (const block of blocks.blocks) {
-    const data = decryptBytes(bytesToHex(podPassword), await bee.downloadData(block.reference, downloadOptions))
+    const data = await bee.downloadData(block.reference, downloadOptions)
     result.set(data, offset)
     offset += data.length
   }

--- a/src/file/utils.ts
+++ b/src/file/utils.ts
@@ -9,7 +9,7 @@ import { FileMetadata, RawFileMetadata } from '../pod/types'
 import { EncryptedReference } from '../utils/hex'
 import { isRawFileMetadata } from '../directory/utils'
 import { getUnixTimestamp } from '../utils/time'
-import { decryptJson, PodPasswordBytes } from '../utils/encryption'
+import { bytesToString } from '../utils/bytes'
 
 /**
  * Asserts that full path string is correct
@@ -91,12 +91,11 @@ export function extractPathInfo(fullPath: string): PathInfo {
  */
 export async function downloadBlocksManifest(
   bee: Bee,
-  podPassword: PodPasswordBytes,
   reference: Reference,
   downloadOptions?: RequestOptions,
 ): Promise<Blocks> {
-  const encryptedData = await bee.downloadData(reference, downloadOptions)
-  const rawBlocks = decryptJson(podPassword, encryptedData)
+  const data = await bee.downloadData(reference, downloadOptions)
+  const rawBlocks = JSON.parse(bytesToString(data))
   assertRawBlocks(rawBlocks)
 
   return rawBlocksToBlocks(rawBlocks)

--- a/test/integration/fdp-class.spec.ts
+++ b/test/integration/fdp-class.spec.ts
@@ -21,7 +21,7 @@ import { Wallet } from 'ethers'
 import { removeZeroFromHex } from '../../src/account/utils'
 import { bytesToString } from '../../src/utils/bytes'
 import { getWalletByIndex, mnemonicToSeed, prepareEthAddress } from '../../src/utils/wallet'
-import { bytesToHex } from '../../src/utils/hex'
+import { assertEncryptedReference, bytesToHex } from '../../src/utils/hex'
 import { base64toReference } from '../../src/file/utils'
 
 async function topUpAddress(fdp: FdpStorage) {
@@ -610,12 +610,11 @@ describe('Fair Data Protocol class', () => {
       // check file metadata
       const metaObject = JSON.parse(decryptedText4)
       const blocksReference = base64toReference(metaObject.fileInodeReference)
-      const encryptedData5 = await bee.downloadData(blocksReference)
-      const encryptedText5 = encryptedData5.text()
-      const decryptedText5 = bytesToString(decryptBytes(bytesToHex(pod1.password), encryptedData5))
+      assertEncryptedReference(blocksReference)
+      const decryptedData5 = await bee.downloadData(blocksReference)
+      const decryptedText5 = decryptedData5.text()
       const metaWords3 = ['blocks', 'size', 'compressedSize', 'reference']
       for (const metaWord of metaWords3) {
-        expect(encryptedText5).not.toContain(metaWord)
         expect(decryptedText5).toContain(metaWord)
       }
 
@@ -623,9 +622,7 @@ describe('Fair Data Protocol class', () => {
       const blocks = JSON.parse(decryptedText5)
       const blockReference = base64toReference(blocks.blocks[0].reference.swarm)
       const encryptedData6 = await bee.downloadData(blockReference)
-      const encryptedText6 = encryptedData6.text()
-      const decryptedText6 = bytesToString(decryptBytes(bytesToHex(pod1.password), encryptedData6))
-      expect(encryptedText6).not.toEqual(contentSmall)
+      const decryptedText6 = encryptedData6.text()
       expect(decryptedText6).toEqual(contentSmall)
     })
   })


### PR DESCRIPTION
So far, the blocks related metadata under the `fileInodeReference` was encrypted with AES with the POD's password as well as the file itself.

It is not necessary since the data is encrypted by Bee on upload. 
The encryption key generated by Bee is saved under the File metadata which is encrypted by the POD's password.
The current encryption handling is wasteful because either client-side encryption or Bee-side encryption should be used.

Nevertheless, this approach has a downside, namely the Bee client will decrypt the requested data instead of the client application itself that can be problematic if the Bee gateway is not trusted.

On the other hand, this approach is faster than encrypting with AES in JavaScript.