### PR TITLE
fix: metadata properties

### DIFF
--- a/src/content-items/directory-item.ts
+++ b/src/content-items/directory-item.ts
@@ -38,6 +38,6 @@ export class DirectoryItem extends ContentItem {
    * @param item raw directory metadata from FairOS
    */
   static fromRawDirectoryMetadata(item: RawDirectoryMetadata): DirectoryItem {
-    return new DirectoryItem(item.Meta.Name, [], item)
+    return new DirectoryItem(item.meta.name, [], item)
   }
 }

--- a/src/content-items/file-item.ts
+++ b/src/content-items/file-item.ts
@@ -24,10 +24,10 @@ export class FileItem extends ContentItem {
   static fromRawFileMetadata(item: RawFileMetadata): FileItem {
     let reference: Reference | undefined
 
-    if (item.file_inode_reference) {
-      reference = CryptoJS.enc.Base64.parse(item.file_inode_reference).toString(CryptoJS.enc.Hex) as Reference
+    if (item.fileInodeReference) {
+      reference = CryptoJS.enc.Base64.parse(item.fileInodeReference).toString(CryptoJS.enc.Hex) as Reference
     }
 
-    return new FileItem(item.file_name, item, Number(item.file_size), reference)
+    return new FileItem(item.fileName, item, Number(item.fileSize), reference)
   }
 }

--- a/src/content-items/handler.ts
+++ b/src/content-items/handler.ts
@@ -56,14 +56,14 @@ export async function addEntryToDirectory(
   }
 
   const itemToAdd = (isFile ? FILE_TOKEN : DIRECTORY_TOKEN) + entryPath
-  parentData.FileOrDirNames = parentData.FileOrDirNames ?? []
+  parentData.fileOrDirNames = parentData.fileOrDirNames ?? []
 
-  if (parentData.FileOrDirNames.includes(itemToAdd)) {
+  if (parentData.fileOrDirNames.includes(itemToAdd)) {
     throw new Error(`${itemText} already listed in the parent directory list`)
   }
 
-  parentData.FileOrDirNames.push(itemToAdd)
-  parentData.Meta.ModificationTime = getUnixTimestamp()
+  parentData.fileOrDirNames.push(itemToAdd)
+  parentData.meta.modificationTime = getUnixTimestamp()
 
   return writeFeedData(
     connection,
@@ -106,8 +106,8 @@ export async function removeEntryFromDirectory(
   assertRawDirectoryMetadata(parentData)
   const itemToRemove = (isFile ? FILE_TOKEN : DIRECTORY_TOKEN) + entryPath
 
-  if (parentData.FileOrDirNames) {
-    parentData.FileOrDirNames = parentData.FileOrDirNames.filter(name => name !== itemToRemove)
+  if (parentData.fileOrDirNames) {
+    parentData.fileOrDirNames = parentData.fileOrDirNames.filter(name => name !== itemToRemove)
   }
 
   return writeFeedData(

--- a/src/directory/handler.ts
+++ b/src/directory/handler.ts
@@ -46,11 +46,11 @@ export async function readDirectory(
   assertRawDirectoryMetadata(parentRawDirectoryMetadata)
   const resultDirectoryItem = DirectoryItem.fromRawDirectoryMetadata(parentRawDirectoryMetadata)
 
-  if (!parentRawDirectoryMetadata.FileOrDirNames) {
+  if (!parentRawDirectoryMetadata.fileOrDirNames) {
     return resultDirectoryItem
   }
 
-  for (let item of parentRawDirectoryMetadata.FileOrDirNames) {
+  for (let item of parentRawDirectoryMetadata.fileOrDirNames) {
     const isFile = item.startsWith(FILE_TOKEN)
     const isDirectory = item.startsWith(DIRECTORY_TOKEN)
 

--- a/src/directory/utils.ts
+++ b/src/directory/utils.ts
@@ -120,14 +120,14 @@ export function isRawDirectoryMetadata(value: unknown): value is RawDirectoryMet
   const data = value as RawDirectoryMetadata
 
   return (
-    typeof data.Meta === 'object' &&
-    isString(data.Meta.Name) &&
-    isString(data.Meta.Path) &&
-    isNumber(data.Meta.AccessTime) &&
-    isNumber(data.Meta.ModificationTime) &&
-    isNumber(data.Meta.CreationTime) &&
-    isNumber(data.Meta.Version) &&
-    (data.FileOrDirNames === null || Array.isArray(data.FileOrDirNames))
+    typeof data.meta === 'object' &&
+    isString(data.meta.name) &&
+    isString(data.meta.path) &&
+    isNumber(data.meta.accessTime) &&
+    isNumber(data.meta.modificationTime) &&
+    isNumber(data.meta.creationTime) &&
+    isNumber(data.meta.version) &&
+    (data.fileOrDirNames === null || Array.isArray(data.fileOrDirNames))
   )
 }
 

--- a/src/directory/utils.ts
+++ b/src/directory/utils.ts
@@ -137,33 +137,33 @@ export function isRawDirectoryMetadata(value: unknown): value is RawDirectoryMet
 export function isRawFileMetadata(value: unknown): value is RawFileMetadata {
   const {
     version,
-    user_address,
-    pod_name,
-    file_path,
-    file_name,
-    file_size,
-    block_size,
-    content_type,
+    userAddress,
+    podName,
+    filePath,
+    fileName,
+    fileSize,
+    blockSize,
+    contentType,
     compression,
-    creation_time,
-    access_time,
-    modification_time,
-    file_inode_reference,
+    creationTime,
+    accessTime,
+    modificationTime,
+    fileInodeReference,
   } = value as RawFileMetadata
 
   return (
     isNumber(version) &&
-    Array.isArray(user_address) &&
-    isString(pod_name) &&
-    isString(file_path) &&
-    isString(file_name) &&
-    isNumber(file_size) &&
-    isNumber(block_size) &&
-    isString(content_type) &&
+    Array.isArray(userAddress) &&
+    isString(podName) &&
+    isString(filePath) &&
+    isString(fileName) &&
+    isNumber(fileSize) &&
+    isNumber(blockSize) &&
+    isString(contentType) &&
     isString(compression) &&
-    isNumber(creation_time) &&
-    isNumber(access_time) &&
-    isNumber(modification_time) &&
-    isString(file_inode_reference)
+    isNumber(creationTime) &&
+    isNumber(accessTime) &&
+    isNumber(modificationTime) &&
+    isString(fileInodeReference)
   )
 }

--- a/src/directory/utils.ts
+++ b/src/directory/utils.ts
@@ -137,8 +137,6 @@ export function isRawDirectoryMetadata(value: unknown): value is RawDirectoryMet
 export function isRawFileMetadata(value: unknown): value is RawFileMetadata {
   const {
     version,
-    userAddress,
-    podName,
     filePath,
     fileName,
     fileSize,
@@ -153,8 +151,6 @@ export function isRawFileMetadata(value: unknown): value is RawFileMetadata {
 
   return (
     isNumber(version) &&
-    Array.isArray(userAddress) &&
-    isString(podName) &&
     isString(filePath) &&
     isString(fileName) &&
     isNumber(fileSize) &&

--- a/src/file/adapter.ts
+++ b/src/file/adapter.ts
@@ -2,7 +2,6 @@ import { Block, Blocks, RawBlock, RawBlocks } from './types'
 import { FileMetadata, RawFileMetadata } from '../pod/types'
 import { base64toReference, referenceToBase64 } from './utils'
 import { stringToBytes } from '../utils/bytes'
-import { prepareEthAddress } from '../utils/wallet'
 
 /**
  * Converts FairOS block format to FDS block format
@@ -11,7 +10,6 @@ import { prepareEthAddress } from '../utils/wallet'
  */
 export function rawBlockToBlock(block: RawBlock): Block {
   return {
-    name: block.Name,
     size: block.Size,
     compressedSize: block.CompressedSize,
     reference: base64toReference(block.Reference.R),
@@ -38,7 +36,6 @@ export function rawBlocksToBlocks(blocks: RawBlocks): Blocks {
  */
 export function blockToRawBlock(block: Block): RawBlock {
   return {
-    Name: block.name,
     Size: block.size,
     CompressedSize: block.compressedSize,
     Reference: {
@@ -75,8 +72,6 @@ export function blocksToManifest(blocks: Blocks): string {
 export function rawFileMetadataToFileMetadata(data: RawFileMetadata): FileMetadata {
   return {
     version: data.version,
-    podAddress: prepareEthAddress(Uint8Array.from(data.userAddress)),
-    podName: data.podName,
     filePath: data.filePath,
     fileName: data.fileName,
     fileSize: data.fileSize,
@@ -87,7 +82,6 @@ export function rawFileMetadataToFileMetadata(data: RawFileMetadata): FileMetada
     accessTime: data.accessTime,
     modificationTime: data.modificationTime,
     blocksReference: base64toReference(data.fileInodeReference),
-    sharedPassword: data.sharedPassword,
   }
 }
 
@@ -97,8 +91,6 @@ export function rawFileMetadataToFileMetadata(data: RawFileMetadata): FileMetada
 export function fileMetadataToRawFileMetadata(data: FileMetadata): RawFileMetadata {
   return {
     version: data.version,
-    userAddress: Array.from(data.podAddress),
-    podName: data.podName,
     filePath: data.filePath,
     fileName: data.fileName,
     fileSize: data.fileSize,
@@ -109,7 +101,6 @@ export function fileMetadataToRawFileMetadata(data: FileMetadata): RawFileMetada
     accessTime: data.accessTime,
     modificationTime: data.modificationTime,
     fileInodeReference: referenceToBase64(data.blocksReference),
-    sharedPassword: data.sharedPassword,
   }
 }
 

--- a/src/file/adapter.ts
+++ b/src/file/adapter.ts
@@ -75,19 +75,19 @@ export function blocksToManifest(blocks: Blocks): string {
 export function rawFileMetadataToFileMetadata(data: RawFileMetadata): FileMetadata {
   return {
     version: data.version,
-    podAddress: prepareEthAddress(Uint8Array.from(data.user_address)),
-    podName: data.pod_name,
-    filePath: data.file_path,
-    fileName: data.file_name,
-    fileSize: data.file_size,
-    blockSize: data.block_size,
-    contentType: data.content_type,
+    podAddress: prepareEthAddress(Uint8Array.from(data.userAddress)),
+    podName: data.podName,
+    filePath: data.filePath,
+    fileName: data.fileName,
+    fileSize: data.fileSize,
+    blockSize: data.blockSize,
+    contentType: data.contentType,
     compression: data.compression,
-    creationTime: data.creation_time,
-    accessTime: data.access_time,
-    modificationTime: data.modification_time,
-    blocksReference: base64toReference(data.file_inode_reference),
-    sharedPassword: data.shared_password,
+    creationTime: data.creationTime,
+    accessTime: data.accessTime,
+    modificationTime: data.modificationTime,
+    blocksReference: base64toReference(data.fileInodeReference),
+    sharedPassword: data.sharedPassword,
   }
 }
 
@@ -97,19 +97,19 @@ export function rawFileMetadataToFileMetadata(data: RawFileMetadata): FileMetada
 export function fileMetadataToRawFileMetadata(data: FileMetadata): RawFileMetadata {
   return {
     version: data.version,
-    user_address: Array.from(data.podAddress),
-    pod_name: data.podName,
-    file_path: data.filePath,
-    file_name: data.fileName,
-    file_size: data.fileSize,
-    block_size: data.blockSize,
-    content_type: data.contentType,
+    userAddress: Array.from(data.podAddress),
+    podName: data.podName,
+    filePath: data.filePath,
+    fileName: data.fileName,
+    fileSize: data.fileSize,
+    blockSize: data.blockSize,
+    contentType: data.contentType,
     compression: data.compression,
-    creation_time: data.creationTime,
-    access_time: data.accessTime,
-    modification_time: data.modificationTime,
-    file_inode_reference: referenceToBase64(data.blocksReference),
-    shared_password: data.sharedPassword,
+    creationTime: data.creationTime,
+    accessTime: data.accessTime,
+    modificationTime: data.modificationTime,
+    fileInodeReference: referenceToBase64(data.blocksReference),
+    sharedPassword: data.sharedPassword,
   }
 }
 

--- a/src/file/adapter.ts
+++ b/src/file/adapter.ts
@@ -10,9 +10,9 @@ import { stringToBytes } from '../utils/bytes'
  */
 export function rawBlockToBlock(block: RawBlock): Block {
   return {
-    size: block.Size,
-    compressedSize: block.CompressedSize,
-    reference: base64toReference(block.Reference.R),
+    size: block.size,
+    compressedSize: block.compressedSize,
+    reference: base64toReference(block.reference.swarm),
   }
 }
 
@@ -22,7 +22,7 @@ export function rawBlockToBlock(block: RawBlock): Block {
  * @param blocks FairOS blocks
  */
 export function rawBlocksToBlocks(blocks: RawBlocks): Blocks {
-  const resultBlocks = blocks.Blocks.map(item => rawBlockToBlock(item))
+  const resultBlocks = blocks.blocks.map(item => rawBlockToBlock(item))
 
   return {
     blocks: resultBlocks,
@@ -36,10 +36,10 @@ export function rawBlocksToBlocks(blocks: RawBlocks): Blocks {
  */
 export function blockToRawBlock(block: Block): RawBlock {
   return {
-    Size: block.size,
-    CompressedSize: block.compressedSize,
-    Reference: {
-      R: referenceToBase64(block.reference),
+    size: block.size,
+    compressedSize: block.compressedSize,
+    reference: {
+      swarm: referenceToBase64(block.reference),
     },
   }
 }
@@ -51,7 +51,7 @@ export function blockToRawBlock(block: Block): RawBlock {
  */
 export function blocksToRawBlocks(blocks: Blocks): RawBlocks {
   return {
-    Blocks: blocks.blocks.map(item => blockToRawBlock(item)),
+    blocks: blocks.blocks.map(item => blockToRawBlock(item)),
   }
 }
 

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -13,14 +13,14 @@ import {
   uploadBytes,
 } from './utils'
 import { writeFeedData } from '../feed/api'
-import { downloadData, generateBlockName } from './handler'
+import { downloadData } from './handler'
 import { blocksToManifest, getFileMetadataRawBytes, rawFileMetadataToFileMetadata } from './adapter'
 import { Blocks, DataUploadOptions, FileReceiveOptions, FileShareInfo } from './types'
 import { addEntryToDirectory, removeEntryFromDirectory } from '../content-items/handler'
 import { Data, Reference } from '@ethersphere/bee-js'
 import { getRawMetadata } from '../content-items/utils'
 import { assertRawFileMetadata, combine } from '../directory/utils'
-import { assertEncryptedReference, bytesToHex, EncryptedReference } from '../utils/hex'
+import { assertEncryptedReference, EncryptedReference } from '../utils/hex'
 import { encryptBytes } from '../utils/encryption'
 
 /**
@@ -77,7 +77,7 @@ export class File {
     assertPodName(podName)
     data = typeof data === 'string' ? stringToBytes(data) : data
     const connection = this.accountData.connection
-    const { podAddress, podWallet, pod } = await getExtendedPodsListByAccountData(this.accountData, podName)
+    const { podWallet, pod } = await getExtendedPodsListByAccountData(this.accountData, podName)
 
     const pathInfo = extractPathInfo(fullPath)
     const now = getUnixTimestamp()
@@ -87,7 +87,6 @@ export class File {
       const currentBlock = data.slice(i * options.blockSize, (i + 1) * options.blockSize)
       const result = await uploadBytes(connection, encryptBytes(pod.password, currentBlock))
       blocks.blocks.push({
-        name: generateBlockName(i),
         size: currentBlock.length,
         compressedSize: currentBlock.length,
         reference: result.reference,
@@ -98,8 +97,6 @@ export class File {
     const blocksReference = (await uploadBytes(connection, manifestBytes)).reference
     const meta: FileMetadata = {
       version: META_VERSION,
-      podAddress,
-      podName,
       filePath: pathInfo.path,
       fileName: pathInfo.filename,
       fileSize: data.length,
@@ -110,7 +107,6 @@ export class File {
       accessTime: now,
       modificationTime: now,
       blocksReference,
-      sharedPassword: '',
     }
 
     await addEntryToDirectory(connection, podWallet, pod.password, pathInfo.path, pathInfo.filename, true)
@@ -156,7 +152,6 @@ export class File {
     const { podAddress, pod } = await getExtendedPodsListByAccountData(this.accountData, podName)
     const meta = (await getRawMetadata(connection.bee, fullPath, podAddress, pod.password)).metadata
     assertRawFileMetadata(meta)
-    meta.sharedPassword = bytesToHex(pod.password)
     const data = JSON.stringify(createFileShareInfo(meta))
 
     return (await uploadBytes(connection, stringToBytes(data))).reference
@@ -195,10 +190,10 @@ export class File {
     assertPodName(podName)
     const sharedInfo = await this.getSharedInfo(reference)
     const connection = this.accountData.connection
-    const { podWallet, podAddress, pod } = await getExtendedPodsListByAccountData(this.accountData, podName)
+    const { podWallet, pod } = await getExtendedPodsListByAccountData(this.accountData, podName)
     let meta = rawFileMetadataToFileMetadata(sharedInfo.meta)
     const fileName = options?.name ?? sharedInfo.meta.fileName
-    meta = updateFileMetadata(meta, podName, parentPath, fileName, podAddress)
+    meta = updateFileMetadata(meta, parentPath, fileName)
     const fullPath = combine(parentPath, fileName)
     await addEntryToDirectory(connection, podWallet, pod.password, parentPath, fileName, true)
     await writeFeedData(connection, fullPath, getFileMetadataRawBytes(meta), podWallet.privateKey, pod.password)

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -21,7 +21,6 @@ import { Data, Reference } from '@ethersphere/bee-js'
 import { getRawMetadata } from '../content-items/utils'
 import { assertRawFileMetadata, combine } from '../directory/utils'
 import { assertEncryptedReference, EncryptedReference } from '../utils/hex'
-import { encryptBytes } from '../utils/encryption'
 
 /**
  * Files management class
@@ -85,7 +84,7 @@ export class File {
     const blocks: Blocks = { blocks: [] }
     for (let i = 0; i < blocksCount; i++) {
       const currentBlock = data.slice(i * options.blockSize, (i + 1) * options.blockSize)
-      const result = await uploadBytes(connection, encryptBytes(pod.password, currentBlock))
+      const result = await uploadBytes(connection, currentBlock)
       blocks.blocks.push({
         size: currentBlock.length,
         compressedSize: currentBlock.length,
@@ -93,7 +92,7 @@ export class File {
       })
     }
 
-    const manifestBytes = encryptBytes(pod.password, stringToBytes(blocksToManifest(blocks)))
+    const manifestBytes = stringToBytes(blocksToManifest(blocks))
     const blocksReference = (await uploadBytes(connection, manifestBytes)).reference
     const meta: FileMetadata = {
       version: META_VERSION,

--- a/src/file/file.ts
+++ b/src/file/file.ts
@@ -156,7 +156,7 @@ export class File {
     const { podAddress, pod } = await getExtendedPodsListByAccountData(this.accountData, podName)
     const meta = (await getRawMetadata(connection.bee, fullPath, podAddress, pod.password)).metadata
     assertRawFileMetadata(meta)
-    meta.shared_password = bytesToHex(pod.password)
+    meta.sharedPassword = bytesToHex(pod.password)
     const data = JSON.stringify(createFileShareInfo(meta))
 
     return (await uploadBytes(connection, stringToBytes(data))).reference
@@ -197,7 +197,7 @@ export class File {
     const connection = this.accountData.connection
     const { podWallet, podAddress, pod } = await getExtendedPodsListByAccountData(this.accountData, podName)
     let meta = rawFileMetadataToFileMetadata(sharedInfo.meta)
-    const fileName = options?.name ?? sharedInfo.meta.file_name
+    const fileName = options?.name ?? sharedInfo.meta.fileName
     meta = updateFileMetadata(meta, podName, parentPath, fileName, podAddress)
     const fullPath = combine(parentPath, fileName)
     await addEntryToDirectory(connection, podWallet, pod.password, parentPath, fileName, true)

--- a/src/file/handler.ts
+++ b/src/file/handler.ts
@@ -1,5 +1,5 @@
 import { wrapBytesWithHelpers } from '../utils/bytes'
-import { Bee, Data, RequestOptions, Utils } from '@ethersphere/bee-js'
+import { Bee, Data, RequestOptions } from '@ethersphere/bee-js'
 import { EthAddress } from '@ethersphere/bee-js/dist/types/utils/eth'
 import { downloadBlocksManifest } from './utils'
 import { FileMetadata } from '../pod/types'

--- a/src/file/handler.ts
+++ b/src/file/handler.ts
@@ -6,8 +6,7 @@ import { FileMetadata } from '../pod/types'
 import { rawFileMetadataToFileMetadata } from './adapter'
 import { assertRawFileMetadata } from '../directory/utils'
 import { getRawMetadata } from '../content-items/utils'
-import { decryptBytes, PodPasswordBytes } from '../utils/encryption'
-import { bytesToHex } from '../utils/hex'
+import { PodPasswordBytes } from '../utils/encryption'
 
 /**
  * File prefix
@@ -63,7 +62,7 @@ export async function downloadData(
     throw new Error('Compressed data is not supported yet')
   }
 
-  const blocks = await downloadBlocksManifest(bee, podPassword, fileMetadata.blocksReference, downloadOptions)
+  const blocks = await downloadBlocksManifest(bee, fileMetadata.blocksReference, downloadOptions)
 
   let totalLength = 0
   for (const block of blocks.blocks) {
@@ -73,7 +72,7 @@ export async function downloadData(
   const result = new Uint8Array(totalLength)
   let offset = 0
   for (const block of blocks.blocks) {
-    const data = decryptBytes(bytesToHex(podPassword), await bee.downloadData(block.reference, downloadOptions))
+    const data = await bee.downloadData(block.reference, downloadOptions)
     result.set(data, offset)
     offset += data.length
   }

--- a/src/file/handler.ts
+++ b/src/file/handler.ts
@@ -57,7 +57,6 @@ export async function downloadData(
   downloadOptions?: RequestOptions,
 ): Promise<Data> {
   const fileMetadata = await getFileMetadata(bee, fullPath, address, podPassword, downloadOptions)
-  podPassword = fileMetadata.sharedPassword ? Utils.hexToBytes(fileMetadata.sharedPassword) : podPassword
 
   if (fileMetadata.compression) {
     // TODO: implement compression support

--- a/src/file/types.ts
+++ b/src/file/types.ts
@@ -19,16 +19,16 @@ export interface DataUploadOptions {
  * FairOS file blocks format
  */
 export interface RawBlocks {
-  Blocks: RawBlock[]
+  blocks: RawBlock[]
 }
 
 /**
  * FairOS file block format
  */
 export interface RawBlock {
-  Size: number
-  CompressedSize: number
-  Reference: { R: string }
+  size: number
+  compressedSize: number
+  reference: { swarm: string }
 }
 
 /**

--- a/src/file/types.ts
+++ b/src/file/types.ts
@@ -26,7 +26,6 @@ export interface RawBlocks {
  * FairOS file block format
  */
 export interface RawBlock {
-  Name: string
   Size: number
   CompressedSize: number
   Reference: { R: string }
@@ -43,7 +42,6 @@ export interface Blocks {
  * FDP file block format
  */
 export interface Block {
-  name: string
   size: number
   compressedSize: number
   reference: Reference

--- a/src/file/utils.ts
+++ b/src/file/utils.ts
@@ -144,7 +144,7 @@ export function isFileShareInfo(value: unknown): value is FileShareInfo {
 export function isRawBlock(value: unknown): value is RawBlock {
   const data = value as RawBlock
 
-  return isObject(value) && isNumber(data.Size) && isNumber(data.CompressedSize) && isString(data.Reference?.R)
+  return isObject(value) && isNumber(data.size) && isNumber(data.compressedSize) && isString(data.reference?.swarm)
 }
 
 /**
@@ -152,8 +152,8 @@ export function isRawBlock(value: unknown): value is RawBlock {
  */
 export function assertRawBlocks(value: unknown): asserts value is RawBlocks {
   const data = value as RawBlocks
-  assertArray(data.Blocks)
-  for (const block of data.Blocks) {
+  assertArray(data.blocks)
+  for (const block of data.blocks) {
     if (!isRawBlock(block)) {
       throw new Error('Incorrect file raw block')
     }

--- a/src/file/utils.ts
+++ b/src/file/utils.ts
@@ -1,5 +1,5 @@
 import { Connection } from '../connection/connection'
-import { Bee, Reference, RequestOptions, UploadResult, Utils } from '@ethersphere/bee-js'
+import { Bee, Reference, RequestOptions, UploadResult } from '@ethersphere/bee-js'
 import { PathInfo } from '../pod/utils'
 import { Blocks, FileShareInfo, RawBlock, RawBlocks } from './types'
 import { rawBlocksToBlocks } from './adapter'
@@ -144,13 +144,7 @@ export function isFileShareInfo(value: unknown): value is FileShareInfo {
 export function isRawBlock(value: unknown): value is RawBlock {
   const data = value as RawBlock
 
-  return (
-    isObject(value) &&
-    isString(data.Name) &&
-    isNumber(data.Size) &&
-    isNumber(data.CompressedSize) &&
-    isString(data.Reference?.R)
-  )
+  return isObject(value) && isNumber(data.Size) && isNumber(data.CompressedSize) && isString(data.Reference?.R)
 }
 
 /**
@@ -193,26 +187,16 @@ export async function getSharedFileInfo(bee: Bee, reference: EncryptedReference)
  * Updates shared metadata with new params
  *
  * @param meta shared metadata
- * @param podName pod name
  * @param filePath parent path of file
  * @param fileName file name
- * @param podAddress pod address
  */
-export function updateFileMetadata(
-  meta: FileMetadata,
-  podName: string,
-  filePath: string,
-  fileName: string,
-  podAddress: Utils.EthAddress,
-): FileMetadata {
+export function updateFileMetadata(meta: FileMetadata, filePath: string, fileName: string): FileMetadata {
   const now = getUnixTimestamp()
 
   return {
     ...meta,
-    podName,
     filePath,
     fileName,
-    podAddress,
     accessTime: now,
     modificationTime: now,
     creationTime: now,

--- a/src/file/utils.ts
+++ b/src/file/utils.ts
@@ -9,7 +9,7 @@ import { FileMetadata, RawFileMetadata } from '../pod/types'
 import { EncryptedReference } from '../utils/hex'
 import { isRawFileMetadata } from '../directory/utils'
 import { getUnixTimestamp } from '../utils/time'
-import { decryptJson, PodPasswordBytes } from '../utils/encryption'
+import { bytesToString } from '../utils/bytes'
 
 /**
  * Asserts that full path string is correct
@@ -91,12 +91,11 @@ export function extractPathInfo(fullPath: string): PathInfo {
  */
 export async function downloadBlocksManifest(
   bee: Bee,
-  podPassword: PodPasswordBytes,
   reference: Reference,
   downloadOptions?: RequestOptions,
 ): Promise<Blocks> {
-  const encryptedData = await bee.downloadData(reference, downloadOptions)
-  const rawBlocks = decryptJson(podPassword, encryptedData)
+  const data = await bee.downloadData(reference, downloadOptions)
+  const rawBlocks = JSON.parse(bytesToString(data))
   assertRawBlocks(rawBlocks)
 
   return rawBlocksToBlocks(rawBlocks)

--- a/src/pod/personal-storage.ts
+++ b/src/pod/personal-storage.ts
@@ -161,8 +161,8 @@ export class PersonalStorage {
       this.accountData.wallet!,
       this.accountData.seed!,
       {
-        name: options?.name ?? data.pod_name,
-        address: prepareEthAddress(data.pod_address),
+        name: options?.name ?? data.podName,
+        address: prepareEthAddress(data.podAddress),
         password: Utils.hexToBytes(data.password),
       },
     )

--- a/src/pod/types.ts
+++ b/src/pod/types.ts
@@ -87,15 +87,15 @@ export interface FileMetadata {
  * Information about a directory
  */
 export interface RawDirectoryMetadata {
-  Meta: {
-    Version: number
-    Path: string
-    Name: string
-    CreationTime: number
-    ModificationTime: number
-    AccessTime: number
+  meta: {
+    version: number
+    path: string
+    name: string
+    creationTime: number
+    modificationTime: number
+    accessTime: number
   }
-  FileOrDirNames: string[] | null
+  fileOrDirNames: string[] | null
 }
 
 /**

--- a/src/pod/types.ts
+++ b/src/pod/types.ts
@@ -54,19 +54,19 @@ export interface SharedPod extends PodName {
  */
 export interface RawFileMetadata {
   version: number
-  user_address: number[]
-  pod_name: string
-  file_path: string
-  file_name: string
-  file_size: number
-  block_size: number
-  content_type: string
+  userAddress: number[]
+  podName: string
+  filePath: string
+  fileName: string
+  fileSize: number
+  blockSize: number
+  contentType: string
   compression: string
-  creation_time: number
-  access_time: number
-  modification_time: number
-  file_inode_reference: string
-  shared_password: HexString
+  creationTime: number
+  accessTime: number
+  modificationTime: number
+  fileInodeReference: string
+  sharedPassword: HexString
 }
 
 /**
@@ -108,9 +108,9 @@ export interface RawDirectoryMetadata {
  * Pod share information
  */
 export interface PodShareInfo {
-  pod_name: string
-  pod_address: string
-  user_address: string
+  podName: string
+  podAddress: string
+  userAddress: string
   password: HexString
 }
 

--- a/src/pod/types.ts
+++ b/src/pod/types.ts
@@ -54,8 +54,6 @@ export interface SharedPod extends PodName {
  */
 export interface RawFileMetadata {
   version: number
-  userAddress: number[]
-  podName: string
   filePath: string
   fileName: string
   fileSize: number
@@ -66,7 +64,6 @@ export interface RawFileMetadata {
   accessTime: number
   modificationTime: number
   fileInodeReference: string
-  sharedPassword: HexString
 }
 
 /**
@@ -74,8 +71,6 @@ export interface RawFileMetadata {
  */
 export interface FileMetadata {
   version: number
-  podAddress: Utils.EthAddress
-  podName: string
   filePath: string
   fileName: string
   fileSize: number
@@ -86,7 +81,6 @@ export interface FileMetadata {
   accessTime: number
   modificationTime: number
   blocksReference: Reference
-  sharedPassword: HexString
 }
 
 /**

--- a/src/pod/utils.ts
+++ b/src/pod/utils.ts
@@ -91,15 +91,15 @@ export function createRawDirectoryMetadata(
   fileOrDirNames?: string[],
 ): Uint8Array {
   const data: RawDirectoryMetadata = {
-    Meta: {
-      Version: version,
-      Path: path,
-      Name: name,
-      CreationTime: creationTime,
-      ModificationTime: modificationTime,
-      AccessTime: accessTime,
+    meta: {
+      version,
+      path,
+      name,
+      creationTime,
+      modificationTime,
+      accessTime,
     },
-    FileOrDirNames: fileOrDirNames ?? null,
+    fileOrDirNames: fileOrDirNames ?? null,
   }
 
   return getRawDirectoryMetadataBytes(data)

--- a/src/pod/utils.ts
+++ b/src/pod/utils.ts
@@ -380,9 +380,9 @@ export function createPodShareInfo(
   password: PodPasswordBytes,
 ): PodShareInfo {
   return {
-    pod_name: podName,
-    pod_address: bytesToHex(podAddress),
-    user_address: bytesToHex(userAddress),
+    podName: podName,
+    podAddress: bytesToHex(podAddress),
+    userAddress: bytesToHex(userAddress),
     password: bytesToHex(password),
   }
 }
@@ -394,10 +394,7 @@ export function isPodShareInfo(value: unknown): value is PodShareInfo {
   const data = value as PodShareInfo
 
   return (
-    isObject(value) &&
-    isString(data.pod_name) &&
-    isHexEthAddress(data.pod_address) &&
-    isHexEthAddress(data.user_address)
+    isObject(value) && isString(data.podName) && isHexEthAddress(data.podAddress) && isHexEthAddress(data.userAddress)
   )
 }
 

--- a/src/shim/crypto.ts
+++ b/src/shim/crypto.ts
@@ -20,6 +20,6 @@ const getRandomValuesNode = <T extends ArrayBufferView | null>(array: T): T => {
   return array
 }
 
-if (isNode && crypto.randomBytes && globalThis) {
+if (isNode && globalThis) {
   globalThis.crypto = { ...globalThis.crypto, getRandomValues: getRandomValuesNode }
 }

--- a/test/integration/fdp-class.browser.spec.ts
+++ b/test/integration/fdp-class.browser.spec.ts
@@ -809,7 +809,6 @@ describe('Fair Data Protocol class - in browser', () => {
       )
 
       expect(sharedData.meta).toBeDefined()
-      expect(sharedData.meta.podName).toEqual(pod)
       expect(sharedData.meta.filePath).toEqual('/')
       expect(sharedData.meta.fileName).toEqual(filenameSmall)
       expect(sharedData.meta.fileSize).toEqual(fileSizeSmall)
@@ -876,7 +875,6 @@ describe('Fair Data Protocol class - in browser', () => {
         customName,
       )
 
-      expect(sharedData.podName).toEqual(pod1)
       expect(sharedData.filePath).toEqual(newFilePath)
       expect(sharedData.fileName).toEqual(filenameSmall)
       expect(sharedData.fileSize).toEqual(fileSizeSmall)
@@ -885,9 +883,7 @@ describe('Fair Data Protocol class - in browser', () => {
       expect(fileInfo.size).toEqual(fileSizeSmall)
       expect(meta.fileName).toEqual(filenameSmall)
       expect(meta.fileSize).toEqual(fileSizeSmall)
-      expect(meta.podName).toEqual(pod1)
       expect(data).toEqual(contentSmall)
-      expect(sharedData1.podName).toEqual(pod1)
       expect(sharedData1.filePath).toEqual(newFilePath)
       expect(sharedData1.fileName).toEqual(customName)
       expect(sharedData1.fileSize).toEqual(fileSizeSmall)

--- a/test/integration/fdp-class.browser.spec.ts
+++ b/test/integration/fdp-class.browser.spec.ts
@@ -435,9 +435,9 @@ describe('Fair Data Protocol class - in browser', () => {
       }, podName)
 
       expect(sharedReference).toBeDefined()
-      expect(sharedData.pod_name).toEqual(podName)
-      expect(sharedData.pod_address).toHaveLength(40)
-      expect(sharedData.user_address).toEqual(walletAddress.toLowerCase().replace('0x', ''))
+      expect(sharedData.podName).toEqual(podName)
+      expect(sharedData.podAddress).toHaveLength(40)
+      expect(sharedData.userAddress).toEqual(walletAddress.toLowerCase().replace('0x', ''))
     })
 
     it('should receive shared pod info', async () => {
@@ -459,9 +459,9 @@ describe('Fair Data Protocol class - in browser', () => {
       }, podName)
 
       expect(sharedReference).toBeDefined()
-      expect(sharedData.pod_name).toEqual(podName)
-      expect(sharedData.pod_address).toHaveLength(40)
-      expect(sharedData.user_address).toEqual(walletAddress.toLowerCase().replace('0x', ''))
+      expect(sharedData.podName).toEqual(podName)
+      expect(sharedData.podAddress).toHaveLength(40)
+      expect(sharedData.userAddress).toEqual(walletAddress.toLowerCase().replace('0x', ''))
     })
 
     it('should save shared pod', async () => {
@@ -809,10 +809,10 @@ describe('Fair Data Protocol class - in browser', () => {
       )
 
       expect(sharedData.meta).toBeDefined()
-      expect(sharedData.meta.pod_name).toEqual(pod)
-      expect(sharedData.meta.file_path).toEqual('/')
-      expect(sharedData.meta.file_name).toEqual(filenameSmall)
-      expect(sharedData.meta.file_size).toEqual(fileSizeSmall)
+      expect(sharedData.meta.podName).toEqual(pod)
+      expect(sharedData.meta.filePath).toEqual('/')
+      expect(sharedData.meta.fileName).toEqual(filenameSmall)
+      expect(sharedData.meta.fileSize).toEqual(fileSizeSmall)
     })
 
     it('should save shared file to a pod', async () => {
@@ -883,9 +883,9 @@ describe('Fair Data Protocol class - in browser', () => {
       expect(files).toHaveLength(1)
       expect(fileInfo.name).toEqual(filenameSmall)
       expect(fileInfo.size).toEqual(fileSizeSmall)
-      expect(meta.file_name).toEqual(filenameSmall)
-      expect(meta.file_size).toEqual(fileSizeSmall)
-      expect(meta.pod_name).toEqual(pod1)
+      expect(meta.fileName).toEqual(filenameSmall)
+      expect(meta.fileSize).toEqual(fileSizeSmall)
+      expect(meta.podName).toEqual(pod1)
       expect(data).toEqual(contentSmall)
       expect(sharedData1.podName).toEqual(pod1)
       expect(sharedData1.filePath).toEqual(newFilePath)

--- a/test/integration/fdp-class.spec.ts
+++ b/test/integration/fdp-class.spec.ts
@@ -578,7 +578,7 @@ describe('Fair Data Protocol class', () => {
       // data decrypts with password stored in the pod
       const decryptedText2 = bytesToString(decryptBytes(bytesToHex(pod1.password), encryptedBytes2))
       // check some keywords from root directory of the pod metadata
-      const metaWords1 = ['Meta', 'Version', 'CreationTime', 'FileOrDirNames']
+      const metaWords1 = ['meta', 'version', 'creationTime', 'fileOrDirNames']
       for (const metaWord of metaWords1) {
         expect(encryptedText2).not.toContain(metaWord)
         expect(decryptedText2).toContain(metaWord)

--- a/test/integration/fdp-class.spec.ts
+++ b/test/integration/fdp-class.spec.ts
@@ -270,9 +270,9 @@ describe('Fair Data Protocol class', () => {
       const sharedReference = await fdp.personalStorage.share(podName)
       expect(sharedReference).toHaveLength(128)
       const sharedData = (await fdp.connection.bee.downloadData(sharedReference)).json() as unknown as PodShareInfo
-      expect(sharedData.pod_name).toEqual(podName)
-      expect(sharedData.pod_address).toHaveLength(40)
-      expect(sharedData.user_address).toEqual(user.address.toLowerCase().replace('0x', ''))
+      expect(sharedData.podName).toEqual(podName)
+      expect(sharedData.podAddress).toHaveLength(40)
+      expect(sharedData.userAddress).toEqual(user.address.toLowerCase().replace('0x', ''))
     })
 
     it('should receive shared pod info', async () => {
@@ -284,9 +284,9 @@ describe('Fair Data Protocol class', () => {
       const sharedReference = await fdp.personalStorage.share(podName)
       const sharedData = await fdp.personalStorage.getSharedInfo(sharedReference)
 
-      expect(sharedData.pod_name).toEqual(podName)
-      expect(sharedData.pod_address).toHaveLength(40)
-      expect(sharedData.user_address).toEqual(user.address.toLowerCase().replace('0x', ''))
+      expect(sharedData.podName).toEqual(podName)
+      expect(sharedData.podAddress).toHaveLength(40)
+      expect(sharedData.userAddress).toEqual(user.address.toLowerCase().replace('0x', ''))
     })
 
     it('should save shared pod', async () => {
@@ -488,10 +488,10 @@ describe('Fair Data Protocol class', () => {
       const sharedData = await fdp.file.getSharedInfo(sharedReference)
 
       expect(sharedData.meta).toBeDefined()
-      expect(sharedData.meta.pod_name).toEqual(pod)
-      expect(sharedData.meta.file_path).toEqual('/')
-      expect(sharedData.meta.file_name).toEqual(filenameSmall)
-      expect(sharedData.meta.file_size).toEqual(fileSizeSmall)
+      expect(sharedData.meta.podName).toEqual(pod)
+      expect(sharedData.meta.filePath).toEqual('/')
+      expect(sharedData.meta.fileName).toEqual(filenameSmall)
+      expect(sharedData.meta.fileSize).toEqual(fileSizeSmall)
     })
 
     it('should save shared file to a pod', async () => {
@@ -525,9 +525,9 @@ describe('Fair Data Protocol class', () => {
       expect(fileInfo.name).toEqual(filenameSmall)
       expect(fileInfo.size).toEqual(fileSizeSmall)
       const meta = fileInfo.raw as RawFileMetadata
-      expect(meta.file_name).toEqual(filenameSmall)
-      expect(meta.file_size).toEqual(fileSizeSmall)
-      expect(meta.pod_name).toEqual(pod1)
+      expect(meta.fileName).toEqual(filenameSmall)
+      expect(meta.fileSize).toEqual(fileSizeSmall)
+      expect(meta.podName).toEqual(pod1)
 
       const data = await fdp1.file.downloadData(pod1, fullFilenameSmallPath)
       expect(data.text()).toEqual(contentSmall)
@@ -609,12 +609,12 @@ describe('Fair Data Protocol class', () => {
         pod,
         filenameSmall,
         'version',
-        'user_address',
-        'pod_name',
-        'file_path',
-        'file_name',
-        'file_size',
-        'file_inode_reference',
+        'userAddress',
+        'podName',
+        'filePath',
+        'fileName',
+        'fileSize',
+        'fileInodeReference',
       ]
       for (const metaWord of metaWords2) {
         expect(encryptedText4).not.toContain(metaWord)
@@ -623,7 +623,7 @@ describe('Fair Data Protocol class', () => {
 
       // check file metadata
       const metaObject = JSON.parse(decryptedText4)
-      const blocksReference = base64toReference(metaObject.file_inode_reference)
+      const blocksReference = base64toReference(metaObject.fileInodeReference)
       const encryptedData5 = await bee.downloadData(blocksReference)
       const encryptedText5 = encryptedData5.text()
       const decryptedText5 = bytesToString(decryptBytes(bytesToHex(pod1.password), encryptedData5))

--- a/test/integration/fdp-class.spec.ts
+++ b/test/integration/fdp-class.spec.ts
@@ -488,7 +488,6 @@ describe('Fair Data Protocol class', () => {
       const sharedData = await fdp.file.getSharedInfo(sharedReference)
 
       expect(sharedData.meta).toBeDefined()
-      expect(sharedData.meta.podName).toEqual(pod)
       expect(sharedData.meta.filePath).toEqual('/')
       expect(sharedData.meta.fileName).toEqual(filenameSmall)
       expect(sharedData.meta.fileSize).toEqual(fileSizeSmall)
@@ -513,7 +512,6 @@ describe('Fair Data Protocol class', () => {
       const newFilePath = '/'
       const sharedData = await fdp1.file.saveShared(pod1, newFilePath, sharedReference)
 
-      expect(sharedData.podName).toEqual(pod1)
       expect(sharedData.filePath).toEqual(newFilePath)
       expect(sharedData.fileName).toEqual(filenameSmall)
       expect(sharedData.fileSize).toEqual(fileSizeSmall)
@@ -527,7 +525,6 @@ describe('Fair Data Protocol class', () => {
       const meta = fileInfo.raw as RawFileMetadata
       expect(meta.fileName).toEqual(filenameSmall)
       expect(meta.fileSize).toEqual(fileSizeSmall)
-      expect(meta.podName).toEqual(pod1)
 
       const data = await fdp1.file.downloadData(pod1, fullFilenameSmallPath)
       expect(data.text()).toEqual(contentSmall)
@@ -535,7 +532,6 @@ describe('Fair Data Protocol class', () => {
       // checking saving with custom name
       const customName = 'NewCustomName.txt'
       const sharedData1 = await fdp1.file.saveShared(pod1, newFilePath, sharedReference, { name: customName })
-      expect(sharedData1.podName).toEqual(pod1)
       expect(sharedData1.filePath).toEqual(newFilePath)
       expect(sharedData1.fileName).toEqual(customName)
       expect(sharedData1.fileSize).toEqual(fileSizeSmall)
@@ -605,17 +601,7 @@ describe('Fair Data Protocol class', () => {
       const encryptedText4 = fileManifestData.data.chunkContent().text()
       const encryptedBytes4 = fileManifestData.data.chunkContent()
       const decryptedText4 = bytesToString(decryptBytes(bytesToHex(pod1.password), encryptedBytes4))
-      const metaWords2 = [
-        pod,
-        filenameSmall,
-        'version',
-        'userAddress',
-        'podName',
-        'filePath',
-        'fileName',
-        'fileSize',
-        'fileInodeReference',
-      ]
+      const metaWords2 = [pod, filenameSmall, 'version', 'filePath', 'fileName', 'fileSize', 'fileInodeReference']
       for (const metaWord of metaWords2) {
         expect(encryptedText4).not.toContain(metaWord)
         expect(decryptedText4).toContain(metaWord)

--- a/test/integration/fdp-class.spec.ts
+++ b/test/integration/fdp-class.spec.ts
@@ -601,7 +601,7 @@ describe('Fair Data Protocol class', () => {
       const encryptedText4 = fileManifestData.data.chunkContent().text()
       const encryptedBytes4 = fileManifestData.data.chunkContent()
       const decryptedText4 = bytesToString(decryptBytes(bytesToHex(pod1.password), encryptedBytes4))
-      const metaWords2 = [pod, filenameSmall, 'version', 'filePath', 'fileName', 'fileSize', 'fileInodeReference']
+      const metaWords2 = [filenameSmall, 'version', 'filePath', 'fileName', 'fileSize', 'fileInodeReference']
       for (const metaWord of metaWords2) {
         expect(encryptedText4).not.toContain(metaWord)
         expect(decryptedText4).toContain(metaWord)
@@ -613,7 +613,7 @@ describe('Fair Data Protocol class', () => {
       const encryptedData5 = await bee.downloadData(blocksReference)
       const encryptedText5 = encryptedData5.text()
       const decryptedText5 = bytesToString(decryptBytes(bytesToHex(pod1.password), encryptedData5))
-      const metaWords3 = ['Blocks', 'Name', 'Size', 'CompressedSize', 'Reference']
+      const metaWords3 = ['blocks', 'size', 'compressedSize', 'reference']
       for (const metaWord of metaWords3) {
         expect(encryptedText5).not.toContain(metaWord)
         expect(decryptedText5).toContain(metaWord)
@@ -621,7 +621,7 @@ describe('Fair Data Protocol class', () => {
 
       // check file block
       const blocks = JSON.parse(decryptedText5)
-      const blockReference = base64toReference(blocks.Blocks[0].Reference.R)
+      const blockReference = base64toReference(blocks.blocks[0].reference.swarm)
       const encryptedData6 = await bee.downloadData(blockReference)
       const encryptedText6 = encryptedData6.text()
       const decryptedText6 = bytesToString(decryptBytes(bytesToHex(pod1.password), encryptedData6))

--- a/test/integration/fdp-class.spec.ts
+++ b/test/integration/fdp-class.spec.ts
@@ -21,7 +21,7 @@ import { Wallet } from 'ethers'
 import { removeZeroFromHex } from '../../src/account/utils'
 import { bytesToString } from '../../src/utils/bytes'
 import { getWalletByIndex, mnemonicToSeed, prepareEthAddress } from '../../src/utils/wallet'
-import { bytesToHex } from '../../src/utils/hex'
+import { assertEncryptedReference, bytesToHex } from '../../src/utils/hex'
 import { base64toReference } from '../../src/file/utils'
 
 async function topUpAddress(fdp: FdpStorage) {
@@ -610,12 +610,11 @@ describe('Fair Data Protocol class', () => {
       // check file metadata
       const metaObject = JSON.parse(decryptedText4)
       const blocksReference = base64toReference(metaObject.fileInodeReference)
-      const encryptedData5 = await bee.downloadData(blocksReference)
-      const encryptedText5 = encryptedData5.text()
-      const decryptedText5 = bytesToString(decryptBytes(bytesToHex(pod1.password), encryptedData5))
+      assertEncryptedReference(blocksReference)
+      const decryptedData5 = await bee.downloadData(blocksReference)
+      const decryptedText5 = decryptedData5.text()
       const metaWords3 = ['blocks', 'size', 'compressedSize', 'reference']
       for (const metaWord of metaWords3) {
-        expect(encryptedText5).not.toContain(metaWord)
         expect(decryptedText5).toContain(metaWord)
       }
 
@@ -623,9 +622,7 @@ describe('Fair Data Protocol class', () => {
       const blocks = JSON.parse(decryptedText5)
       const blockReference = base64toReference(blocks.blocks[0].reference.swarm)
       const encryptedData6 = await bee.downloadData(blockReference)
-      const encryptedText6 = encryptedData6.text()
-      const decryptedText6 = bytesToString(decryptBytes(bytesToHex(pod1.password), encryptedData6))
-      expect(encryptedText6).not.toEqual(contentSmall)
+      const decryptedText6 = encryptedData6.text()
       expect(decryptedText6).toEqual(contentSmall)
     })
   })

--- a/test/types.ts
+++ b/test/types.ts
@@ -12,11 +12,11 @@ export interface FairOSDirectoryItems {
 export interface FairOSDirectoryItem {
   name: string
   size: string
-  content_type: string
-  block_size: string
-  creation_time: string
-  modification_time: string
-  access_time: string
+  contentType: string
+  blockSize: string
+  creationTime: string
+  modificationTime: string
+  accessTime: string
 }
 
 /**
@@ -24,8 +24,8 @@ export interface FairOSDirectoryItem {
  */
 export interface FairOSFileItem {
   name: string
-  content_type: string
-  creation_time: string
-  modification_time: string
-  access_time: string
+  contentType: string
+  creationTime: string
+  modificationTime: string
+  accessTime: string
 }

--- a/test/unit/file/utils.spec.ts
+++ b/test/unit/file/utils.spec.ts
@@ -15,11 +15,11 @@ describe('file/utils', () => {
           },
         ] as Block[],
         result: {
-          Blocks: [
+          blocks: [
             {
-              Size: 17,
-              CompressedSize: 17,
-              Reference: { R: 'KNPeilXXVD+m8uSBnoBunStOGZlwOmMjLwqoEm/SRmg=' },
+              size: 17,
+              compressedSize: 17,
+              reference: { swarm: 'KNPeilXXVD+m8uSBnoBunStOGZlwOmMjLwqoEm/SRmg=' },
             },
           ],
         },
@@ -58,36 +58,36 @@ describe('file/utils', () => {
           },
         ] as Block[],
         result: {
-          Blocks: [
+          blocks: [
             {
-              Size: 1000000,
-              CompressedSize: 1000000,
-              Reference: { R: 'CGpJuGm6EE96RSInah8uJCvjWNovmqNOM3EUkzVXdpo=' },
+              size: 1000000,
+              compressedSize: 1000000,
+              reference: { swarm: 'CGpJuGm6EE96RSInah8uJCvjWNovmqNOM3EUkzVXdpo=' },
             },
             {
-              Size: 1000000,
-              CompressedSize: 1000000,
-              Reference: { R: '9bo/c4cxvhhiB0FbhLwMj4MLCxwEPBfKztlZtVp1ykk=' },
+              size: 1000000,
+              compressedSize: 1000000,
+              reference: { swarm: '9bo/c4cxvhhiB0FbhLwMj4MLCxwEPBfKztlZtVp1ykk=' },
             },
             {
-              Size: 1000000,
-              CompressedSize: 1000000,
-              Reference: { R: '7PzVmuKPS+CABTZXeHRgmGkxgZImQE48AIYmwhYY2vw=' },
+              size: 1000000,
+              compressedSize: 1000000,
+              reference: { swarm: '7PzVmuKPS+CABTZXeHRgmGkxgZImQE48AIYmwhYY2vw=' },
             },
             {
-              Size: 1000000,
-              CompressedSize: 1000000,
-              Reference: { R: 'Qn6R91f0UYObSmRFn/OSrYCBmOizKMJbm5yK3zFXUgg=' },
+              size: 1000000,
+              compressedSize: 1000000,
+              reference: { swarm: 'Qn6R91f0UYObSmRFn/OSrYCBmOizKMJbm5yK3zFXUgg=' },
             },
             {
-              Size: 1000000,
-              CompressedSize: 1000000,
-              Reference: { R: 'jb4/Mz1jesXXTnKT456pGB3FiG1I5YRtDhT24wPsUEo=' },
+              size: 1000000,
+              compressedSize: 1000000,
+              reference: { swarm: 'jb4/Mz1jesXXTnKT456pGB3FiG1I5YRtDhT24wPsUEo=' },
             },
             {
-              Size: 242880,
-              CompressedSize: 242880,
-              Reference: { R: 'SSTJ+l0KD8y5djxId+IUIVUiI2pFRRInvG/amf7zU4k=' },
+              size: 242880,
+              compressedSize: 242880,
+              reference: { swarm: 'SSTJ+l0KD8y5djxId+IUIVUiI2pFRRInvG/amf7zU4k=' },
             },
           ],
         },

--- a/test/unit/file/utils.spec.ts
+++ b/test/unit/file/utils.spec.ts
@@ -9,7 +9,6 @@ describe('file/utils', () => {
       {
         blocks: [
           {
-            name: 'block-00000',
             size: 17,
             compressedSize: 17,
             reference: '28d3de8a55d7543fa6f2e4819e806e9d2b4e1999703a63232f0aa8126fd24668' as Reference,
@@ -18,7 +17,6 @@ describe('file/utils', () => {
         result: {
           Blocks: [
             {
-              Name: 'block-00000',
               Size: 17,
               CompressedSize: 17,
               Reference: { R: 'KNPeilXXVD+m8uSBnoBunStOGZlwOmMjLwqoEm/SRmg=' },
@@ -29,37 +27,31 @@ describe('file/utils', () => {
       {
         blocks: [
           {
-            name: 'block-00000',
             size: 1000000,
             compressedSize: 1000000,
             reference: '086a49b869ba104f7a4522276a1f2e242be358da2f9aa34e337114933557769a',
           },
           {
-            name: 'block-00001',
             size: 1000000,
             compressedSize: 1000000,
             reference: 'f5ba3f738731be186207415b84bc0c8f830b0b1c043c17caced959b55a75ca49',
           },
           {
-            name: 'block-00002',
             size: 1000000,
             compressedSize: 1000000,
             reference: 'ecfcd59ae28f4be080053657787460986931819226404e3c008626c21618dafc',
           },
           {
-            name: 'block-00003',
             size: 1000000,
             compressedSize: 1000000,
             reference: '427e91f757f451839b4a64459ff392ad808198e8b328c25b9b9c8adf31575208',
           },
           {
-            name: 'block-00004',
             size: 1000000,
             compressedSize: 1000000,
             reference: '8dbe3f333d637ac5d74e7293e39ea9181dc5886d48e5846d0e14f6e303ec504a',
           },
           {
-            name: 'block-00005',
             size: 242880,
             compressedSize: 242880,
             reference: '4924c9fa5d0a0fccb9763c4877e214215522236a45451227bc6fda99fef35389',
@@ -68,37 +60,31 @@ describe('file/utils', () => {
         result: {
           Blocks: [
             {
-              Name: 'block-00000',
               Size: 1000000,
               CompressedSize: 1000000,
               Reference: { R: 'CGpJuGm6EE96RSInah8uJCvjWNovmqNOM3EUkzVXdpo=' },
             },
             {
-              Name: 'block-00001',
               Size: 1000000,
               CompressedSize: 1000000,
               Reference: { R: '9bo/c4cxvhhiB0FbhLwMj4MLCxwEPBfKztlZtVp1ykk=' },
             },
             {
-              Name: 'block-00002',
               Size: 1000000,
               CompressedSize: 1000000,
               Reference: { R: '7PzVmuKPS+CABTZXeHRgmGkxgZImQE48AIYmwhYY2vw=' },
             },
             {
-              Name: 'block-00003',
               Size: 1000000,
               CompressedSize: 1000000,
               Reference: { R: 'Qn6R91f0UYObSmRFn/OSrYCBmOizKMJbm5yK3zFXUgg=' },
             },
             {
-              Name: 'block-00004',
               Size: 1000000,
               CompressedSize: 1000000,
               Reference: { R: 'jb4/Mz1jesXXTnKT456pGB3FiG1I5YRtDhT24wPsUEo=' },
             },
             {
-              Name: 'block-00005',
               Size: 242880,
               CompressedSize: 242880,
               Reference: { R: 'SSTJ+l0KD8y5djxId+IUIVUiI2pFRRInvG/amf7zU4k=' },


### PR DESCRIPTION
All properties are changed from snake case to camel case and some properties have been taken out from directory and file metadata.

Also, changed content encryption from AES + Bee to only Bee. 
First, it was necessary because the `sharedPassword` is not present anymore in `FileMetadata`.
By this, the file sharing can still work without exposing the password used for encrypting POD metadata.
More info #181 

Closes https://github.com/fairDataSociety/fdp-storage/issues/177