### PR TITLE
chore: upgrade fdp-contracts lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@ethersphere/bee-js": "github:fairDataSociety/bee-js",
-        "@fairdatasociety/fdp-contracts-js": "^2.1.0",
+        "@fairdatasociety/fdp-contracts-js": "^3.6.0",
         "crypto-js": "^4.1.1",
         "ethers": "^5.5.2",
         "js-sha3": "^0.8.0"
@@ -3013,9 +3013,9 @@
       }
     },
     "node_modules/@fairdatasociety/fdp-contracts-js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fairdatasociety/fdp-contracts-js/-/fdp-contracts-js-2.1.0.tgz",
-      "integrity": "sha512-bmsCj2IKR2feB4Gb56pX4y66pe6Yrr0gOIqQvSo8gzTkBnXzlmnUPtMZi082GwW6Bsxk+xu7eFMpUFPxcAnIgg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@fairdatasociety/fdp-contracts-js/-/fdp-contracts-js-3.6.0.tgz",
+      "integrity": "sha512-yiV4wMBJzLcDhHF/wAD5XUlVsCVkppj2KA/zESgJdUfJ9y5jyTrNcBWARe3fQaBnVhW57WDHvaT+VLutf+nk0Q==",
       "peerDependencies": {
         "ethers": ">=5.6.4"
       }
@@ -16657,9 +16657,9 @@
       }
     },
     "@fairdatasociety/fdp-contracts-js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fairdatasociety/fdp-contracts-js/-/fdp-contracts-js-2.1.0.tgz",
-      "integrity": "sha512-bmsCj2IKR2feB4Gb56pX4y66pe6Yrr0gOIqQvSo8gzTkBnXzlmnUPtMZi082GwW6Bsxk+xu7eFMpUFPxcAnIgg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@fairdatasociety/fdp-contracts-js/-/fdp-contracts-js-3.6.0.tgz",
+      "integrity": "sha512-yiV4wMBJzLcDhHF/wAD5XUlVsCVkppj2KA/zESgJdUfJ9y5jyTrNcBWARe3fQaBnVhW57WDHvaT+VLutf+nk0Q==",
       "requires": {}
     },
     "@fluffy-spoon/substitute": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@ethersphere/bee-js": "github:fairDataSociety/bee-js",
-    "@fairdatasociety/fdp-contracts-js": "^2.1.0",
+    "@fairdatasociety/fdp-contracts-js": "^3.6.0",
     "crypto-js": "^4.1.1",
     "ethers": "^5.5.2",
     "js-sha3": "^0.8.0"


### PR DESCRIPTION
Upgrades fdp-contracts to 3.6.0.