### PR TITLE
feat!: retryable registration (#247)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,11 @@ const wallet = fdp.account.createWallet() // after creating a wallet, the user m
 // Associate the created wallet with the username in the smart contract.
 // This method makes the account portable.
 // Seed is saved encrypted in Swarm.
-await fdp.account.register('myusername', 'mypassword')
+// Registration is performed in two steps, first create a registration object
+const registrationRequest = fdp.account.createRegistrationRequest('myusername', 'mypassword')
+// Then pass this object to the register method
+await fdp.account.register(registrationRequest)
+// If registration fails, it can be safely retried by passing the same object again
 
 // If necessary, the account can be re-uploaded to Swarm.
 await fdp.personalStorage.reuploadPortableAccount('username', 'password')

--- a/src/account/account-data.ts
+++ b/src/account/account-data.ts
@@ -157,7 +157,7 @@ export class AccountData {
    * Creates a request object that is used to invoke the 'register' method. This object
    * encapsulates the complete state of registration process. In case when registration
    * fails in any of the steps, the 'register' method can be safely invoked again with
-   * the existing RegistrationRequest object. The process will contine from the failed
+   * the existing RegistrationRequest object. The process will continue from the failed
    * step.
    *
    * @param username FDP username

--- a/src/account/types.ts
+++ b/src/account/types.ts
@@ -1,6 +1,8 @@
 import { Utils } from '@ethersphere/bee-js'
 import { isEthAddress, isObject } from '../utils/type'
 import { isValidMnemonic } from 'ethers/lib/utils'
+import { ServiceRequest } from '@fairdatasociety/fdp-contracts-js/build/types/model/service-request.model'
+import { RegisterUsernameRequestData } from '@fairdatasociety/fdp-contracts-js'
 
 /**
  * Migrate options with possibility to migrate with an address
@@ -14,6 +16,16 @@ export interface AddressOptions {
  */
 export interface MnemonicOptions {
   mnemonic: string
+}
+
+/**
+ * This objects encapsulates state of registration process.
+ */
+export interface RegistrationRequest {
+  username: string
+  password: string
+  ensCompleted: boolean
+  ensRequest?: ServiceRequest<RegisterUsernameRequestData>
 }
 
 /**

--- a/test/integration/fdp-class.fairos.spec.ts
+++ b/test/integration/fdp-class.fairos.spec.ts
@@ -22,7 +22,7 @@ describe('Fair Data Protocol with FairOS-dfs', () => {
       await topUpFdp(fdp)
       const nameHash = utils.namehash(`${user.username}.fds`)
       const publicKey = Wallet.fromMnemonic(user.mnemonic).publicKey.replace('0x', '')
-      await fdp.account.register(user.username, user.password)
+      await fdp.account.register(fdp.account.createRegistrationRequest(user.username, user.password))
       const response = await fairos.login(user.username, user.password)
       expect(response.status).toEqual(200)
       expect(response.data.accessToken).toBeDefined()
@@ -63,7 +63,7 @@ describe('Fair Data Protocol with FairOS-dfs', () => {
       const podName2 = generateRandomHexString()
 
       await topUpFdp(fdp)
-      await fdp.account.register(user.username, user.password)
+      await fdp.account.register(fdp.account.createRegistrationRequest(user.username, user.password))
       await fdp.personalStorage.create(podName1)
       await fairos.login(user.username, user.password)
       const response = await fairos.podLs()
@@ -130,7 +130,7 @@ describe('Fair Data Protocol with FairOS-dfs', () => {
       const podName1 = generateRandomHexString()
 
       await topUpFdp(fdp)
-      await fdp.account.register(user.username, user.password)
+      await fdp.account.register(fdp.account.createRegistrationRequest(user.username, user.password))
       await fdp.personalStorage.create(podName1)
       await fairos.login(user.username, user.password)
       const fairosList1 = (await fairos.podLs()).data as PodsList
@@ -202,7 +202,7 @@ describe('Fair Data Protocol with FairOS-dfs', () => {
       const fullDirectoryName2 = '/' + directoryName2
 
       await topUpFdp(fdp)
-      await fdp.account.register(user.username, user.password)
+      await fdp.account.register(fdp.account.createRegistrationRequest(user.username, user.password))
       await fdp.personalStorage.create(podName1)
       await fdp.directory.create(podName1, fullDirectoryName1)
       await fairos.login(user.username, user.password)
@@ -252,7 +252,7 @@ describe('Fair Data Protocol with FairOS-dfs', () => {
       const fullDirectoryName3 = '/' + directoryName3
 
       await topUpFdp(fdp)
-      await fdp.account.register(user.username, user.password)
+      await fdp.account.register(fdp.account.createRegistrationRequest(user.username, user.password))
       await fairos.login(user.username, user.password)
       await fairos.podNew(podName1, user.password)
       await fairos.dirMkdir(podName1, fullDirectoryName1, user.password)
@@ -287,7 +287,7 @@ describe('Fair Data Protocol with FairOS-dfs', () => {
       const fullDirectoryName1 = '/' + directoryName1
 
       await topUpFdp(fdp)
-      await fdp.account.register(user.username, user.password)
+      await fdp.account.register(fdp.account.createRegistrationRequest(user.username, user.password))
       await fdp.personalStorage.create(podName1)
       await fdp.directory.create(podName1, fullDirectoryName1)
       await fairos.login(user.username, user.password)
@@ -351,7 +351,7 @@ describe('Fair Data Protocol with FairOS-dfs', () => {
       const fullFilenameBigPath = '/' + filenameBig
 
       await topUpFdp(fdp)
-      await fdp.account.register(user.username, user.password)
+      await fdp.account.register(fdp.account.createRegistrationRequest(user.username, user.password))
       await fdp.personalStorage.create(podName1)
       await fdp.file.uploadData(podName1, fullFilenameBigPath, contentBig)
 
@@ -383,7 +383,7 @@ describe('Fair Data Protocol with FairOS-dfs', () => {
       const fullFilenameBigPath1 = '/' + filenameBig1
 
       await topUpFdp(fdp)
-      await fdp.account.register(user.username, user.password)
+      await fdp.account.register(fdp.account.createRegistrationRequest(user.username, user.password))
       await fairos.login(user.username, user.password)
       await fairos.podNew(podName1, user.password)
       const response1 = await fairos.fileUpload(podName1, '/', contentBig, filenameBig)
@@ -423,7 +423,7 @@ describe('Fair Data Protocol with FairOS-dfs', () => {
       const fullFilenameBigPath = '/' + filenameBig
 
       await topUpFdp(fdp)
-      await fdp.account.register(user.username, user.password)
+      await fdp.account.register(fdp.account.createRegistrationRequest(user.username, user.password))
       await fdp.personalStorage.create(podName1)
       await fdp.file.uploadData(podName1, fullFilenameBigPath, contentBig)
       await fairos.login(user.username, user.password)

--- a/test/integration/fdp-class.spec.ts
+++ b/test/integration/fdp-class.spec.ts
@@ -61,20 +61,26 @@ describe('Fair Data Protocol class', () => {
       const fdp = createFdp()
       const user = generateUser(fdp)
 
-      await expect(fdp.account.register(user.username, user.password)).rejects.toThrow('Not enough funds')
+      await expect(
+        fdp.account.register(fdp.account.createRegistrationRequest(user.username, user.password)),
+      ).rejects.toThrow('Not enough funds')
     })
 
     it('should register users', async () => {
       const fdp = createFdp()
 
-      await expect(fdp.account.register('user', 'password')).rejects.toThrow('Account wallet not found')
+      await expect(fdp.account.register(fdp.account.createRegistrationRequest('user', 'password'))).rejects.toThrow(
+        'Account wallet not found',
+      )
 
       for (let i = 0; i < 2; i++) {
         const fdp = createFdp()
 
         const user = generateUser(fdp)
         await topUpFdp(fdp)
-        const reference = await fdp.account.register(user.username, user.password)
+        const reference = await fdp.account.register(
+          fdp.account.createRegistrationRequest(user.username, user.password),
+        )
         expect(reference).toBeDefined()
       }
     })
@@ -84,10 +90,10 @@ describe('Fair Data Protocol class', () => {
       const user = generateUser(fdp)
       await topUpFdp(fdp)
 
-      await fdp.account.register(user.username, user.password)
-      await expect(fdp.account.register(user.username, user.password)).rejects.toThrow(
-        `ENS: Username ${user.username} is not available`,
-      )
+      await fdp.account.register(fdp.account.createRegistrationRequest(user.username, user.password))
+      await expect(
+        fdp.account.register(fdp.account.createRegistrationRequest(user.username, user.password)),
+      ).rejects.toThrow(`ENS: Username ${user.username} is not available`)
     })
 
     it('should migrate v1 user to v2', async () => {
@@ -105,9 +111,9 @@ describe('Fair Data Protocol class', () => {
       const loggedWallet = await fdp.account.login(user.username, user.password)
       expect(loggedWallet.address).toEqual(user.address)
 
-      await expect(fdp2.account.register(user.username, user.password)).rejects.toThrow(
-        `ENS: Username ${user.username} is not available`,
-      )
+      await expect(
+        fdp2.account.register(fdp.account.createRegistrationRequest(user.username, user.password)),
+      ).rejects.toThrow(`ENS: Username ${user.username} is not available`)
     })
   })
 
@@ -118,7 +124,7 @@ describe('Fair Data Protocol class', () => {
       const user = generateUser(fdp)
       await topUpFdp(fdp)
 
-      const data = await fdp.account.register(user.username, user.password)
+      const data = await fdp.account.register(fdp.account.createRegistrationRequest(user.username, user.password))
       expect(data).toBeDefined()
 
       const wallet1 = await fdp1.account.login(user.username, user.password)
@@ -139,7 +145,7 @@ describe('Fair Data Protocol class', () => {
       const user = generateUser(fdp)
       await topUpFdp(fdp)
 
-      await fdp.account.register(user.username, user.password)
+      await fdp.account.register(fdp.account.createRegistrationRequest(user.username, user.password))
       await expect(fdp.account.login(user.username, generateUser().password)).rejects.toThrow('Incorrect password')
       await expect(fdp.account.login(user.username, '')).rejects.toThrow('Incorrect password')
     })
@@ -151,7 +157,7 @@ describe('Fair Data Protocol class', () => {
       const userFake = generateUser()
       await topUpFdp(fdp)
 
-      const data = await fdp.account.register(user.username, user.password)
+      const data = await fdp.account.register(fdp.account.createRegistrationRequest(user.username, user.password))
       expect(data).toBeDefined()
 
       fdp1.account.setAccountFromMnemonic(userFake.mnemonic)


### PR DESCRIPTION
The `register` method now accepts a request object that can be used to invoke the method any number of times until it returns a successful response.

Closes #247 