### PR TITLE
fix: username availability error text

### DIFF
--- a/src/account/account-data.ts
+++ b/src/account/account-data.ts
@@ -138,7 +138,7 @@ export class AccountData {
     assertPassword(password)
 
     if (await this.ens.isUsernameAvailable(username)) {
-      throw new Error(`Username "${username}" does not exists`)
+      throw new Error(`Username "${username}" does not exist`)
     }
 
     const publicKey = await this.ens.getPublicKey(username)

--- a/test/integration/fdp-class.browser.spec.ts
+++ b/test/integration/fdp-class.browser.spec.ts
@@ -237,7 +237,7 @@ describe('Fair Data Protocol class - in browser', () => {
 
         await window.shouldFail(
           fdp.account.login(fakeUser.username, fakeUser.password),
-          `Username "${fakeUser.username}" does not exists`,
+          `Username "${fakeUser.username}" does not exist`,
         )
       }, jsonFakeUser)
     })

--- a/test/integration/fdp-class.spec.ts
+++ b/test/integration/fdp-class.spec.ts
@@ -136,7 +136,7 @@ describe('Fair Data Protocol class', () => {
 
       const fakeUser = generateUser(fdp)
       await expect(fdp.account.login(fakeUser.username, fakeUser.password)).rejects.toThrow(
-        `Username "${fakeUser.username}" does not exists`,
+        `Username "${fakeUser.username}" does not exist`,
       )
     })
 


### PR DESCRIPTION
Fixed typo for user login from
`Username "${username}" does not exists`
to 
`Username "${username}" does not exist`

Close: https://github.com/fairDataSociety/fairdrive-theapp/issues/509