### PR TITLE
fix: Add atob/btoa polyfill for Node.js builds

### DIFF
--- a/src/polyfills/base64.ts
+++ b/src/polyfills/base64.ts
@@ -1,0 +1,23 @@
+/**
+ * Base64 polyfill for Node.js environments
+ *
+ * This provides atob/btoa compatibility for Node.js < 18
+ * Node.js 18+ has these built-in, but webpack bundling may not expose them properly
+ *
+ * Fixes: https://github.com/fairDataSociety/fdp-storage/issues/244
+ */
+
+// Only polyfill if not already available
+if (typeof globalThis.atob === 'undefined') {
+  globalThis.atob = (str: string): string => {
+    return Buffer.from(str, 'base64').toString('binary')
+  }
+}
+
+if (typeof globalThis.btoa === 'undefined') {
+  globalThis.btoa = (str: string): string => {
+    return Buffer.from(str, 'binary').toString('base64')
+  }
+}
+
+export {}

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -19,7 +19,11 @@ const base = async (env?: Partial<WebpackEnvParams>): Promise<Configuration> => 
   const filename =
     env?.fileName ||
     ['index', isBrowser ? '.browser' : null, isProduction ? '.min' : null, '.js'].filter(Boolean).join('')
-  const entry = Path.resolve(__dirname, 'src')
+  // For Node.js builds, include base64 polyfill to provide atob/btoa compatibility
+  // Fixes: https://github.com/fairDataSociety/fdp-storage/issues/244
+  const entry = isBrowser
+    ? Path.resolve(__dirname, 'src')
+    : [Path.resolve(__dirname, 'src', 'polyfills', 'base64.ts'), Path.resolve(__dirname, 'src')]
   const path = Path.resolve(__dirname, 'dist')
   const target = env?.target || 'web' // 'node' or 'web'
   const plugins: WebpackPluginInstance[] = [


### PR DESCRIPTION
Fixes #244

## Problem

When `fdp-cli` upgraded to `fdp-storage` 0.8.0, tests failed with:
```
ReferenceError: atob is not defined
```

This occurs because `atob`/`btoa` are browser-only APIs not available in Node.js < 18, and even in Node 18+ webpack bundling may not expose them properly to the global scope.

## Root Cause

The webpack build for Node.js targets doesn't include a polyfill for these browser APIs. When code paths in `fdp-storage` reference `atob` or `btoa`, Node.js environments throw a `ReferenceError`.

## Solution

**Created `src/polyfills/base64.ts`:**
- Polyfills `atob`/`btoa` using Node.js `Buffer` API
- Only applies if not already defined (safe for Node 18+)
- Uses `globalThis` for maximum compatibility

**Modified `webpack.config.ts`:**
- Node.js builds now include the polyfill as first entry point
- Browser builds unchanged (no overhead)
- Polyfill auto-loads before main library code

## Testing

After merging:
1. Run `npm run prepare` to rebuild distribution bundles
2. The Node.js bundle will automatically include the polyfill
3. `fdp-cli` tests should pass without `ReferenceError`

## Impact

- ✅ Fixes Node.js compatibility issue
- ✅ No impact on browser builds (unchanged)
- ✅ No runtime overhead (polyfill only loads if needed)
- ✅ Safe for Node.js 16, 18, 20+ (checks before defining)

## References

- Issue: #244
- Affected PR: fairDataSociety/fdp-cli#75
- Node.js `atob` docs: https://nodejs.org/api/buffer.html#buffers-and-character-encodings

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>