### PR TITLE
Fix race condition when reading newly created pods (#259)

### DIFF
--- a/src/feed/api.ts
+++ b/src/feed/api.ts
@@ -16,6 +16,40 @@ import { EthAddress } from '../utils/eth'
 export const DELETE_FEED_MAGIC_WORD = '__Fair__'
 
 /**
+ * Helper to retry feed data reads with exponential backoff
+ *
+ * Handles eventual consistency issues with Bee gateways where chunks
+ * may not be immediately available after write operations (issue #259)
+ *
+ * @param fn async function to retry
+ * @param maxRetries maximum number of retry attempts (default: 3)
+ * @param initialDelayMs initial delay in milliseconds (default: 500)
+ */
+async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  maxRetries = 3,
+  initialDelayMs = 500,
+): Promise<T> {
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      return await fn()
+    } catch (error) {
+      // On last attempt, throw the error
+      if (attempt === maxRetries - 1) {
+        throw error
+      }
+
+      // Exponential backoff: 500ms, 1000ms, 2000ms
+      const delayMs = initialDelayMs * Math.pow(2, attempt)
+      await new Promise(resolve => setTimeout(resolve, delayMs))
+    }
+  }
+
+  // TypeScript safety - should never reach here
+  throw new Error('Retry logic error')
+}
+
+/**
  * Finds and downloads the latest feed content
  *
  * @param bee Bee client
@@ -37,6 +71,34 @@ export async function getFeedData(
 
     return bee.downloadChunk(chunkReference, requestOptions)
   })
+}
+
+/**
+ * Finds and downloads the latest feed content with retry logic
+ *
+ * Use this variant when reading feed data immediately after a write operation
+ * to handle eventual consistency issues with Bee gateways (issue #259)
+ *
+ * @param bee Bee client
+ * @param topic topic for calculation swarm chunk
+ * @param address Ethereum address for calculation swarm chunk
+ * @param requestOptions download chunk requestOptions
+ * @param maxRetries maximum number of retry attempts (default: 3)
+ * @param initialDelayMs initial delay in milliseconds (default: 500)
+ */
+export async function getFeedDataWithRetry(
+  bee: Bee,
+  topic: string,
+  address: EthAddress | Uint8Array,
+  requestOptions?: BeeRequestOptions,
+  maxRetries = 3,
+  initialDelayMs = 500,
+): Promise<LookupAnswer> {
+  return retryWithBackoff(
+    () => getFeedData(bee, topic, address, requestOptions),
+    maxRetries,
+    initialDelayMs,
+  )
 }
 
 /**

--- a/src/pod/utils.ts
+++ b/src/pod/utils.ts
@@ -36,7 +36,7 @@ import { bytesToHex, EncryptedReference, isHexEthAddress } from '../utils/hex'
 import { getExtendedPodsList } from './api'
 import { Epoch, getFirstEpoch } from '../feed/lookup/epoch'
 import { getUnixTimestamp } from '../utils/time'
-import { getFeedData } from '../feed/api'
+import { getFeedData, getFeedDataWithRetry } from '../feed/api'
 import { createRootDirectory } from '../directory/handler'
 import { Connection } from '../connection/connection'
 import { AccountData } from '../account/account-data'
@@ -689,6 +689,9 @@ export function jsonSharedPodToSharedPod(pod: SharedPod): SharedPodPrepared {
 /**
  * Retrieves pods data for a given address.
  *
+ * Uses retry logic to handle eventual consistency issues with Bee gateways
+ * where pods data may not be immediately available after write operations (issue #259)
+ *
  * @param {Bee} bee - The bee client object.
  * @param {EthAddress} address - The address to look up pods data for.
  * @param {BeeRequestOptions} [requestOptions] - The request options.
@@ -703,14 +706,14 @@ export async function getPodsData(
   let podsVersion = PodsVersion.V2
   let lookupAnswer
   try {
-    lookupAnswer = await getFeedData(bee, getPodV2Topic(), address, requestOptions)
+    lookupAnswer = await getFeedDataWithRetry(bee, getPodV2Topic(), address, requestOptions)
     // eslint-disable-next-line no-empty
   } catch (e) {}
 
   // if V2 does not exist, try V1
   if (!lookupAnswer) {
     try {
-      lookupAnswer = await getFeedData(bee, POD_TOPIC, address, requestOptions)
+      lookupAnswer = await getFeedDataWithRetry(bee, POD_TOPIC, address, requestOptions)
       podsVersion = PodsVersion.V1
       // eslint-disable-next-line no-empty
     } catch (e) {}


### PR DESCRIPTION
## Summary

Fixes #259 - Adds exponential backoff retry logic to handle eventual consistency issues with Bee gateways where chunks may not be immediately available after write operations.

## Root Cause

Bee nodes need time to propagate chunks through their internal state machine (accepted → validated → stored → retrievable). The issue manifests when:
1. Pod metadata is written via SOC  
2. Immediate read attempt returns 500 "read chunk failed"
3. After 2-5 seconds, the chunk becomes available

## Solution

- Implement `getFeedDataWithRetry()` wrapper with exponential backoff (500ms, 1000ms, 2000ms)
- Update `getPodsData()` to use retry logic for both V2 and V1 pod topic lookups
- Minimal changes - preserves all existing behavior

## Testing

- Tested against bee-1.fairdatasociety.org (production - shows the issue)
- Tested against fdp-play (local dev - works without retry)
- Full test suite passes

## Changes

- `src/feed/api.ts`: Add retry helper and `getFeedDataWithRetry()` function (+62 lines)
- `src/pod/utils.ts`: Use `getFeedDataWithRetry()` in `getPodsData()` (+6 lines, -3 lines)

Total: 68 insertions, 3 deletions