### PR TITLE
security: bundle ws + bn.js + follow-redirects + babel overrides (closes #313, #314, #315)

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,10 @@
     "npm": ">=9.0.0"
   },
   "overrides": {
-    "basic-ftp": "^5.2.0"
+    "basic-ftp": "^5.2.0",
+    "ws": ">=8.17.1",
+    "bn.js": ">=4.12.3",
+    "follow-redirects": ">=1.16.0",
+    "@babel/plugin-transform-modules-systemjs": ">=7.29.4"
   }
 }


### PR DESCRIPTION
## Summary

Bundled `npm.overrides` fix for four Dependabot alert clusters that have been open 19–25 days with no PR:

| Issue | Package | Severity | Scope | Override |
|-------|---------|----------|-------|----------|
| #313 | ws | HIGH | runtime | `>=8.17.1` |
| #314 | bn.js (4.x + 5.x) | medium | runtime | `>=4.12.3` |
| #314 | follow-redirects | medium | runtime | `>=1.16.0` |
| #315 | @babel/plugin-transform-modules-systemjs | HIGH | dev | `>=7.29.4` |

## Changes

Single file: `package.json` — 4 lines added to the existing `overrides` block.

## Safety

All four are version-floor overrides with no breaking API changes in the patched ranges. `ws` patches a DoS triggered only by abnormally large HTTP header sets (Bee node HTTP, not user-controlled). `bn.js` patches an infinite-loop on malformed BN constructor input (all fdp-storage callers pass well-formed hex/BigNumber). `follow-redirects` patches auth-header propagation across cross-domain redirects (only affects HTTP redirect chains). `@babel/plugin-transform-modules-systemjs` is dev-scope only — the advisory explicitly states trusted-code compilation is unaffected, and fdp-storage does not use the `systemjs` output format.

## CI expectation

CI will show the same pre-existing fdp-play queen-node / ENS-sidecar failures present on all open PRs (#308, #310, #312, #317). These are unrelated to this change — see #305 / disambiguation comment on #308.

Closes #313, #314, #315